### PR TITLE
Make the code easy on the eye

### DIFF
--- a/cartographer/src/main/java/org/commonjava/maven/cartographer/ops/GraphRenderingOps.java
+++ b/cartographer/src/main/java/org/commonjava/maven/cartographer/ops/GraphRenderingOps.java
@@ -320,16 +320,14 @@ public class GraphRenderingOps
                     logger.debug( "Saving POM artifact for possible later inclusion (if no other artifact is found for this project): {}",
                                   artifact );
                     pomArtifact = artifact;
-                    continue;
                 }
                 else
                 {
                     logger.debug( "Including non-POM artifact: {}", artifact );
                     nonPomSeen = true;
+                    logger.debug( "Adding dependency: {}", artifact );
+                    addDependencyTo( model, artifact, spec, r, dm, dto );
                 }
-
-                logger.debug( "Adding dependency: {}", artifact );
-                addDependencyTo( model, artifact, spec, r, dm, dto );
             }
 
             if ( !nonPomSeen )


### PR DESCRIPTION
The continue statement caused that the code in else block was executed
under the same cisrcumstances as the code after the if-else, but it was
not clear at first sight.

So moving the code after the if-else into the else block and dropping
the continue statement seems like a reasonable step to me.