### PR TITLE
Fix managed presets

### DIFF
--- a/model-java/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
+++ b/model-java/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
@@ -66,9 +66,9 @@ public class ScopeWithEmbeddedProjectsFilter
         DependencyScope filterScope = scope == null ? DependencyScope.runtime : scope;
         this.acceptManaged = acceptManaged;
         this.filter =
-            new OrFilter( new DependencyFilter( filterScope, ScopeTransitivity.maven, false, true, true, null ),
-                          new DependencyFilter( DependencyScope.embedded, ScopeTransitivity.maven, false, true, true,
-                                                null ) );
+            new OrFilter( new DependencyFilter( filterScope, ScopeTransitivity.maven, acceptManaged, true, true, null ),
+                          new DependencyFilter( DependencyScope.embedded, ScopeTransitivity.maven, acceptManaged, true,
+                                                true, null ) );
         this.excludes = exc;
     }
 

--- a/model-java/src/main/java/org/commonjava/maven/cartographer/preset/ScopedProjectFilter.java
+++ b/model-java/src/main/java/org/commonjava/maven/cartographer/preset/ScopedProjectFilter.java
@@ -67,7 +67,7 @@ public class ScopedProjectFilter
     {
         DependencyScope filterScope = scope == null ? DependencyScope.runtime : scope;
         this.acceptManaged = acceptManaged;
-        this.filter = new DependencyFilter( filterScope, ScopeTransitivity.maven, false, true, true, null );
+        this.filter = new DependencyFilter( filterScope, ScopeTransitivity.maven, acceptManaged, true, true, null );
         this.excludes = excludes;
     }
 


### PR DESCRIPTION
Presets called managed-requires and managed-build-requires are designed to contain also artifacts referenced in dependencyManagement sections of the artifacts already included in the graph. There is a flag in the respective filters called acceptManaged providing a quick info if these artifacts should or should not be included.

Based on the flag value filter does not accept managed dependencies if set to false. If set to true, the decision is passed to the embedded filter, which was set to not accept managed dependencies regardless of the flag value.

This commit updates the initialization of the embedded filters to respect the acceptManaged value.