### PR TITLE
Allow configuration of graph mutator in GraphDescription

### DIFF
--- a/cartographer/src/main/java/org/commonjava/cartographer/graph/GraphResolver.java
+++ b/cartographer/src/main/java/org/commonjava/cartographer/graph/GraphResolver.java
@@ -36,6 +36,7 @@ import org.commonjava.maven.atlas.graph.ViewParams;
 import org.commonjava.maven.atlas.graph.filter.AndFilter;
 import org.commonjava.maven.atlas.graph.filter.AnyFilter;
 import org.commonjava.maven.atlas.graph.filter.ProjectRelationshipFilter;
+import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
 import org.commonjava.maven.atlas.graph.mutate.ManagedDependencyMutator;
 import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
@@ -212,13 +213,11 @@ public class GraphResolver
             }
             else
             {
-                final ViewParams params =
-                                new ViewParams.Builder( recipe.getWorkspaceId(), desc.rootsArray() ).withFilter(
-                                                desc.filter() )
-                                                                                                    .withMutator( new ManagedDependencyMutator() )
-                                                                                                    .withSelections(
-                                                                                                                    recipe.getVersionSelections() )
-                                                                                                    .build();
+                final ViewParams params = new ViewParams.Builder( recipe.getWorkspaceId(), desc.rootsArray() )
+                                                        .withFilter( desc.filter() )
+                                                        .withMutator( desc.getMutatorInstance() )
+                                                        .withSelections( recipe.getVersionSelections() )
+                                                        .build();
                 // ensure the graph is available.
                 RelationshipGraph graph = null;
                 try
@@ -303,12 +302,11 @@ public class GraphResolver
 
         if ( !recipe.isResolve() )
         {
-            final ViewParams params = new ViewParams.Builder( recipe.getWorkspaceId(), desc.rootsArray() ).withFilter(
-                            desc.filter() )
-                                                                                                          .withMutator( new ManagedDependencyMutator() )
-                                                                                                          .withSelections(
-                                                                                                                          recipe.getVersionSelections() )
-                                                                                                          .build();
+            final ViewParams params = new ViewParams.Builder( recipe.getWorkspaceId(), desc.rootsArray() )
+                                                    .withFilter( desc.filter() )
+                                                    .withMutator( desc.getMutatorInstance() )
+                                                    .withSelections( recipe.getVersionSelections() )
+                                                    .build();
             // ensure the graph is available.
             try
             {
@@ -339,12 +337,11 @@ public class GraphResolver
             specifics.add( specific );
         }
 
-        final ViewParams params = new ViewParams.Builder( recipe.getWorkspaceId(), specifics ).withFilter(
-                        aggOptions.getFilter() )
-                                                                                              .withMutator( aggOptions.getMutator() )
-                                                                                              .withSelections(
-                                                                                                              recipe.getVersionSelections() )
-                                                                                              .build();
+        final ViewParams params = new ViewParams.Builder( recipe.getWorkspaceId(), specifics )
+                                                .withFilter( aggOptions.getFilter() )
+                                                .withMutator( desc.getMutatorInstance() )
+                                                .withSelections( recipe.getVersionSelections() )
+                                                .build();
 
         sourceManager.activateWorkspaceSources( params, discoveryConfig.getLocations() );
 

--- a/cartographer/src/test/java/org/commonjava/cartographer/INTERNAL/ops/ResolveOpsImplTest.java
+++ b/cartographer/src/test/java/org/commonjava/cartographer/INTERNAL/ops/ResolveOpsImplTest.java
@@ -114,6 +114,7 @@ public class ResolveOpsImplTest
                                                                                                            new ScopeWithEmbeddedProjectsFilter(
                                                                                                                                                 DependencyScope.runtime,
                                                                                                                                                 false ),
+                                                                                                           null,
                                                                                                            Collections.singleton( recipeRoot ) ) ) ) );
 
         recipe.setResolve( false );

--- a/model-java/src/main/java/org/commonjava/cartographer/graph/agg/AggregationOptions.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/agg/AggregationOptions.java
@@ -18,9 +18,9 @@ package org.commonjava.cartographer.graph.agg;
 import org.commonjava.maven.atlas.graph.filter.AnyFilter;
 import org.commonjava.maven.atlas.graph.filter.ProjectRelationshipFilter;
 import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
-import org.commonjava.maven.atlas.graph.mutate.ManagedDependencyMutator;
 import org.commonjava.maven.atlas.graph.util.RelationshipUtils;
 import org.commonjava.cartographer.graph.discover.DiscoveryConfig;
+import org.commonjava.cartographer.graph.mutator.MutatorSelector;
 import org.commonjava.cartographer.graph.preset.ScopedProjectFilter;
 
 import java.net.URI;
@@ -44,8 +44,6 @@ public class AggregationOptions
 
     private DiscoveryConfig dc;
 
-    private GraphMutator mutator;
-
     public AggregationOptions()
     {
         this.filter = new ScopedProjectFilter();
@@ -60,7 +58,6 @@ public class AggregationOptions
         this.discoverySource = options.getDiscoverySource();
         this.discoveryTimeoutMillis = options.getDiscoveryTimeoutMillis();
         this.dc = options.getDiscoveryConfig();
-        this.mutator = options.getMutator();
     }
 
     public AggregationOptions setFilter( final ProjectRelationshipFilter filter )
@@ -99,11 +96,6 @@ public class AggregationOptions
         return this;
     }
 
-    public AggregationOptions setMutator( final GraphMutator mutator )
-    {
-        this.mutator = mutator;
-        return this;
-    }
     public ProjectRelationshipFilter getFilter()
     {
         return filter == null ? AnyFilter.INSTANCE : filter;
@@ -122,8 +114,8 @@ public class AggregationOptions
     public DiscoveryConfig getDiscoveryConfig()
     {
         return dc == null ? new DiscoveryConfig( discoverySource ).setEnabled( discoveryEnabled )
-                                                                         .setTimeoutMillis( discoveryTimeoutMillis )
-                                                                         .setMutator( mutator ) : dc;
+                                                                  .setTimeoutMillis( discoveryTimeoutMillis )
+                          : dc;
     }
 
     public boolean isDiscoveryEnabled()
@@ -144,9 +136,9 @@ public class AggregationOptions
     @Override
     public String toString()
     {
-        return String.format( "AggregationOptions [\n\tmutator=%s\n\tprocessIncomplete=%s"
+        return String.format( "AggregationOptions [\n\tprocessIncomplete=%s"
                                   + "\n\tprocessVariable=%s" + "\n\tdiscoveryEnabled=%s"
-                                  + "\n\tdiscoveryTimeoutMillis=%s" + "\n\n\tfilter:\n\n%s\n\n]", mutator,
+                                  + "\n\tdiscoveryTimeoutMillis=%s" + "\n\n\tfilter:\n\n%s\n\n]",
                               processIncomplete, processVariable, discoveryEnabled,
                               discoveryTimeoutMillis, filter );
     }
@@ -157,13 +149,7 @@ public class AggregationOptions
         this.discoverySource = dc.getDiscoverySource();
         this.discoveryEnabled = dc.isEnabled();
         this.discoveryTimeoutMillis = dc.getTimeoutMillis();
-        this.mutator = dc.getMutator();
         return this;
-    }
-
-    public GraphMutator getMutator()
-    {
-        return mutator == null ? new ManagedDependencyMutator() : mutator;
     }
 
 }

--- a/model-java/src/main/java/org/commonjava/cartographer/graph/discover/DiscoveryConfig.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/discover/DiscoveryConfig.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.cartographer.graph.discover;
 
+import org.commonjava.cartographer.graph.mutator.MutatorSelector;
 import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
-import org.commonjava.maven.atlas.graph.mutate.ManagedDependencyMutator;
 import org.commonjava.maven.galley.model.Location;
 
 import java.net.URI;
@@ -36,8 +36,6 @@ public class DiscoveryConfig
     private List<? extends Location> discoveryLocations;
 
     private Collection<String> patchers;
-
-    private GraphMutator mutator;
 
     private boolean storeRelationships = true;
 
@@ -91,7 +89,6 @@ public class DiscoveryConfig
         this.enabled = discoveryConfig.isEnabled();
         this.timeoutMillis = discoveryConfig.getTimeoutMillis();
         this.discoverySource = discoveryConfig.getDiscoverySource();
-        this.mutator = discoveryConfig.getMutator();
         this.discoveryLocations = discoveryConfig.getLocations();
         this.storeRelationships = discoveryConfig.isStoreRelationships();
         this.includeBuildSection = discoveryConfig.isIncludeBuildSection();
@@ -135,17 +132,6 @@ public class DiscoveryConfig
     public Collection<String> getEnabledPatchers()
     {
         return patchers == null ? Collections.<String> emptySet() : patchers;
-    }
-
-    public GraphMutator getMutator()
-    {
-        return mutator == null ? new ManagedDependencyMutator() : mutator;
-    }
-
-    public DiscoveryConfig setMutator( final GraphMutator mutator )
-    {
-        this.mutator = mutator;
-        return this;
     }
 
     public List<? extends Location> getLocations()

--- a/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/ManagedDependencyGraphMutatorFactory.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/ManagedDependencyGraphMutatorFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cartographer.graph.mutator;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.commonjava.atservice.annotation.Service;
+import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
+import org.commonjava.maven.atlas.graph.mutate.ManagedDependencyMutator;
+
+@Named( "managed-mutator" )
+@ApplicationScoped
+@Service( MutatorFactory.class )
+public class ManagedDependencyGraphMutatorFactory implements MutatorFactory
+{
+
+    public static final String[] IDS = { "managed", "managed-dependency", ManagedDependencyMutator.class.getSimpleName() };
+
+    @Override
+    public String[] getMutatorIds()
+    {
+        return IDS;
+    }
+
+    @Override
+    public GraphMutator newMutator( final String mutatorId )
+    {
+        return ManagedDependencyMutator.INSTANCE;
+    }
+
+}

--- a/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/MutatorFactory.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/MutatorFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cartographer.graph.mutator;
+
+import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
+
+public interface MutatorFactory
+{
+
+    /**
+     * @return array of mutator IDs created by this factory
+     */
+    String[] getMutatorIds();
+
+    /**
+     * Provides a mutator instance. In cases when it is possible and desired it returns always the same default
+     * instance rather than creating a new one for each call.
+     *
+     * @param mutatorId the mutator ID
+     * @return the mutator instance
+     */
+    GraphMutator newMutator( String mutatorId );
+
+}

--- a/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/MutatorSelector.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/MutatorSelector.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cartographer.graph.mutator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
+import org.commonjava.maven.atlas.graph.mutate.ManagedDependencyMutator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class MutatorSelector
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private Instance<MutatorFactory> mutatorFactoryInstances;
+
+    private static Map<String, MutatorFactory> mutatorFactories;
+
+    private static final String DEFAULT_MUTATOR_ID = ManagedDependencyMutator.class.getSimpleName().toLowerCase();
+
+    public MutatorSelector()
+    {
+        final ServiceLoader<MutatorFactory> factories = ServiceLoader.load( MutatorFactory.class );
+        mapMutators( factories );
+    }
+
+    public MutatorSelector( final Iterable<MutatorFactory> mutatorFactoryInstances )
+    {
+        mapMutators( mutatorFactoryInstances );
+    }
+
+    @PostConstruct
+    public void mapPresets()
+    {
+        mapMutators( mutatorFactoryInstances );
+    }
+
+    private void mapMutators( final Iterable<MutatorFactory> mutatorFactoryInstances )
+    {
+        mutatorFactories = new HashMap<String, MutatorFactory>();
+        for ( final MutatorFactory factory : mutatorFactoryInstances )
+        {
+            final String[] named = factory.getMutatorIds();
+            if ( named != null )
+            {
+                for ( final String name : named )
+                {
+                    logger.info( "Loaded mutator factory: {} ({})", name, factory );
+                    mutatorFactories.put( name.toLowerCase(), factory );
+                }
+            }
+            else
+            {
+                logger.info( "Skipped unnamed mutator factory: {}", factory );
+            }
+        }
+    }
+
+    public GraphMutator getGraphMutator( final String mutator )
+    {
+        if ( mutator == null )
+        {
+            return getDefaultMutator();
+        }
+        else
+        {
+            final MutatorFactory factory = mutatorFactories.get( mutator.toLowerCase() );
+            if ( factory == null )
+            {
+                // TODO: Is there a more elegant way to handle this?
+                throw new IllegalArgumentException( "Invalid mutator: " + mutator );
+            }
+
+            final GraphMutator mutatorInstance = factory.newMutator( mutator );
+            
+            logger.info( "Returning mutator: {} for ID: {}", mutatorInstance, mutator );
+            return mutatorInstance;
+        }
+    }
+
+    public static GraphMutator getDefaultMutator()
+    {
+        return mutatorFactories.get( DEFAULT_MUTATOR_ID ).newMutator( DEFAULT_MUTATOR_ID );
+    }
+
+}

--- a/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/NoOpGraphMutatorFactory.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/NoOpGraphMutatorFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.cartographer.graph.mutator;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import org.commonjava.atservice.annotation.Service;
+import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
+import org.commonjava.maven.atlas.graph.mutate.NoOpGraphMutator;
+
+@Named( "noop-mutator" )
+@ApplicationScoped
+@Service( MutatorFactory.class )
+public class NoOpGraphMutatorFactory implements MutatorFactory
+{
+
+    public static final String[] IDS = { "noop", NoOpGraphMutator.class.getSimpleName() };
+
+    @Override
+    public String[] getMutatorIds()
+    {
+        return IDS;
+    }
+
+    @Override
+    public GraphMutator newMutator( final String mutatorId )
+    {
+        return NoOpGraphMutator.INSTANCE;
+    }
+
+}

--- a/model-java/src/main/java/org/commonjava/cartographer/request/GraphDescription.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/request/GraphDescription.java
@@ -17,18 +17,21 @@ package org.commonjava.cartographer.request;
 
 import java.util.*;
 
-import org.commonjava.maven.atlas.graph.ViewParams;
 import org.commonjava.maven.atlas.graph.filter.ProjectRelationshipFilter;
+import org.commonjava.maven.atlas.graph.mutate.GraphMutator;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
-import org.commonjava.maven.atlas.ident.ref.SimpleProjectVersionRef;
 
-// TODO: Allow configuration of mutator too...
+
 public class GraphDescription
 {
 
     private Set<ProjectVersionRef> roots;
 
     private String preset;
+    
+    private String mutator;
+    
+    private GraphMutator mutatorInstance;
 
     private Map<String, Object> presetParams;
 
@@ -40,29 +43,33 @@ public class GraphDescription
     {
     }
 
-    public GraphDescription( final String preset, final Map<String, ?> presetParams,
-                             final Collection<ProjectVersionRef> roots )
+    public GraphDescription( final String preset, final String mutator,
+                             final Map<String, ?> presetParams, final Collection<ProjectVersionRef> roots )
     {
         this.preset = preset;
+        this.mutator = mutator;
         this.presetParams = presetParams == null ? new TreeMap<>() : new TreeMap<>( presetParams );
         this.roots = new TreeSet<ProjectVersionRef>( roots );
     }
 
-    public GraphDescription( final String preset, final Map<String, ?> presetParams,
+    public GraphDescription( final String preset, final String mutator, final Map<String, ?> presetParams,
                              final ProjectVersionRef... roots )
     {
-        this( preset, presetParams, Arrays.asList( roots ) );
+        this( preset, mutator, presetParams, Arrays.asList( roots ) );
     }
 
-    public GraphDescription( final ProjectRelationshipFilter filter, final Collection<ProjectVersionRef> roots )
+    public GraphDescription( final ProjectRelationshipFilter filter, final String mutator,
+                             final Collection<ProjectVersionRef> roots )
     {
         this.filter = filter;
+        this.mutator = mutator;
         this.roots = new TreeSet<ProjectVersionRef>( roots );
     }
 
-    public GraphDescription( final ProjectRelationshipFilter filter, final ProjectVersionRef... roots )
+    public GraphDescription( final ProjectRelationshipFilter filter, final String mutator,
+                             final ProjectVersionRef... roots )
     {
-        this( filter, Arrays.asList( roots ) );
+        this( filter, mutator, Arrays.asList( roots ) );
     }
 
     public Set<ProjectVersionRef> getRoots()
@@ -75,6 +82,11 @@ public class GraphDescription
         return preset;
     }
 
+    public String getMutator()
+    {
+        return mutator;
+    }
+
     public void setRoots( final Set<ProjectVersionRef> roots )
     {
         this.roots = new TreeSet<>( roots );
@@ -83,6 +95,11 @@ public class GraphDescription
     public void setPreset( final String preset )
     {
         this.preset = preset;
+    }
+
+    public void setMutator( final String mutator )
+    {
+        this.mutator = mutator;
     }
 
     public ProjectVersionRef[] rootsArray()
@@ -100,10 +117,21 @@ public class GraphDescription
         this.filter = filter;
     }
 
+    public GraphMutator getMutatorInstance()
+    {
+        return mutatorInstance;
+    }
+    
+    public void setMutatorInstance( final GraphMutator mutatorInstance )
+    {
+        this.mutatorInstance = mutatorInstance;
+    }
+
     @Override
     public String toString()
     {
-        return String.format( "GraphDescription [roots=%s, preset=%s, filter=%s, presetParams=%s]", roots, preset, filter, presetParams );
+        return String.format( "GraphDescription [roots=%s, preset=%s, mutator=%s, filter=%s, presetParams=%s]", roots,
+                              preset, mutator, filter, presetParams );
     }
 
     public void normalize()
@@ -128,6 +156,7 @@ public class GraphDescription
         final int prime = 31;
         int result = 1;
         result = prime * result + ( ( preset == null ) ? 0 : preset.hashCode() );
+        result = prime * result + ( ( mutator == null ) ? 0 : mutator.hashCode() );
         result = prime * result + ( ( presetParams == null ) ? 0 : presetParams.hashCode() );
         result = prime * result + ( ( roots == null ) ? 0 : roots.hashCode() );
         return result;
@@ -168,6 +197,17 @@ public class GraphDescription
             }
         }
         else if ( !preset.equals( other.preset ) )
+        {
+            return false;
+        }
+        if ( mutator == null )
+        {
+            if ( other.mutator != null )
+            {
+                return false;
+            }
+        }
+        else if ( !mutator.equals( other.mutator ) )
         {
             return false;
         }

--- a/model-java/src/main/java/org/commonjava/cartographer/request/build/GraphDescriptionBuilder.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/request/build/GraphDescriptionBuilder.java
@@ -106,11 +106,11 @@ public class GraphDescriptionBuilder
     {
         if ( preset != null )
         {
-            return new GraphDescription( preset, presetParams, roots );
+            return new GraphDescription( preset, null, presetParams, roots );
         }
         else
         {
-            return new GraphDescription( filter, roots );
+            return new GraphDescription( filter, null, roots );
         }
     }
 


### PR DESCRIPTION
There is mutator and mutatorIntance fields in GraphDescription class similarly to
preset - filter pair. I.e. mutator is the desired mutator's string ID and
mutatorInstance is resolved GraphMutator instance set in RecipeResolver.resolve().

Removing mutator field from DiscoveryConfig and AggregationOptions because mutator
is graph-scoped, not request-scoped. So if a request contains graph composition
each graph can use different mutator. Therefore it doesn't make sense to store it
inside those two classes of which is (always?) used one instance for all subgraphs.

Follows https://github.com/Commonjava/atlas/pull/49