### PR TITLE
Do not close the graph connection too early

### DIFF
--- a/cartographer/src/main/java/org/commonjava/cartographer/INTERNAL/ops/GraphOpsImpl.java
+++ b/cartographer/src/main/java/org/commonjava/cartographer/INTERNAL/ops/GraphOpsImpl.java
@@ -107,10 +107,6 @@ public class GraphOpsImpl
                                     "Failed to open / traverse the graph (for paths operation): " + ex.getMessage(),
                                     ex );
                 }
-                finally
-                {
-                    CartoGraphUtils.closeGraphQuietly( graph );
-                }
 
                 final Set<List<ProjectRelationship<?, ?>>> discoveredPaths = paths.getDiscoveredPaths();
 


### PR DESCRIPTION
It doesn't make much sense to close the graph (connection) in the
extractor because it was not opened there. When we closed the connection
at that point it was not available when collected relationships were
processed below and it led to InvalidRefException.

The extractor is used only in resolveAndExtractMultiGraph which opens and
closes all graphs used, so it is counter-productive to try to help it.
