### PR TITLE
Group paths by the target, not by the starting artifact

### DIFF
--- a/cartographer/src/main/java/org/commonjava/cartographer/INTERNAL/ops/GraphOpsImpl.java
+++ b/cartographer/src/main/java/org/commonjava/cartographer/INTERNAL/ops/GraphOpsImpl.java
@@ -126,7 +126,7 @@ public class GraphOpsImpl
                         }
                     }
 
-                    final ProjectVersionRef ref = path.get( 0 ).getDeclaring();
+                    final ProjectVersionRef ref = path.get( path.size() - 1 ).getTarget();
                     result.addPath( ref, new ProjectPath( path ) );
                 }
             }


### PR DESCRIPTION
It was like that in former versions and this change makes the reports in the Maven Repository Builder buggy. The paths are used there (and possibly anywhere else) to identify which relationships paths lead to a desired artifact. Therefore it is handy to get them grouped by the targets, not by roots.