### PR TITLE
Build filter properly for PathTraversal

### DIFF
--- a/cartographer/src/main/java/org/commonjava/cartographer/INTERNAL/ops/GraphOpsImpl.java
+++ b/cartographer/src/main/java/org/commonjava/cartographer/INTERNAL/ops/GraphOpsImpl.java
@@ -123,7 +123,7 @@ public class GraphOpsImpl
                 final RelationshipGraph graph = graphMap.get( desc );
                 final ProjectRelationshipFilter filter = desc.filter();
 
-                final PathsTraversal paths = new PathsTraversal( filter, recipe.getTargets() );
+                final PathsTraversal paths = new PathsTraversal( recipe.buildFilter( filter ), recipe.getTargets() );
                 try
                 {
                     graph.traverse( paths, TraversalType.depth_first );

--- a/pom.xml
+++ b/pom.xml
@@ -32,29 +32,29 @@
 
   <name>Cartographer Project-Discovery API</name>
   <inceptionYear>2013</inceptionYear>
-  
+
   <scm>
     <connection>scm:git:https://github.com/Commonjava/cartographer.git</connection>
     <developerConnection>scm:git:git@github.com:Commonjava/cartographer.git</developerConnection>
     <url>http://github.com/Commonjava/cartographer</url>
     <tag>HEAD</tag>
   </scm>
-  
+
   <properties>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>
-    
-    <atlasVersion>0.16.3-SNAPSHOT</atlasVersion>
-    <galleyVersion>0.13.5-SNAPSHOT</galleyVersion>
-    <partylineVersion>1.10-SNAPSHOT</partylineVersion>
 
-    <propulsorVersion>1.3-SNAPSHOT</propulsorVersion>
+    <atlasVersion>0.17.0</atlasVersion>
+    <galleyVersion>0.13.6-SNAPSHOT</galleyVersion>
+    <partylineVersion>1.9.2</partylineVersion>
+
+    <propulsorVersion>1.2</propulsorVersion>
     <configVersion>0.8</configVersion>
     <swaggerVersion>1.5.9</swaggerVersion>
     <!-- <indyVersion>1.1.0-SNAPSHOT</indyVersion> -->
     <indyVersion>1.0.0</indyVersion>
     <jhttpcVersion>1.3</jhttpcVersion>
-    <weftVersion>1.4-SNAPSHOT</weftVersion>
+    <weftVersion>1.4.1</weftVersion>
 
     <it-skip>true</it-skip>
 
@@ -91,7 +91,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      
+
       <dependency>
         <groupId>org.commonjava.cartographer</groupId>
         <artifactId>cartographer-model-java</artifactId>
@@ -400,7 +400,7 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
   </dependencies>
-  
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Without this the paths method uses filter with no exclusions at some
places which makes Cartographer fail when accessing the relationship
again with correct filter.