### PR TITLE
Fix IllegalArgumentException: Invalid mutator: NOOP

### DIFF
--- a/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/MutatorSelector.java
+++ b/model-java/src/main/java/org/commonjava/cartographer/graph/mutator/MutatorSelector.java
@@ -19,11 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
 import org.commonjava.cartographer.graph.mutate.GraphMutator;
 import org.commonjava.cartographer.graph.mutate.ManagedDependencyMutator;
 import org.slf4j.Logger;
@@ -34,9 +30,6 @@ public class MutatorSelector
 {
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
-
-    @Inject
-    private Instance<MutatorFactory> mutatorFactoryInstances;
 
     private static Map<String, MutatorFactory> mutatorFactories;
 
@@ -49,12 +42,6 @@ public class MutatorSelector
     }
 
     public MutatorSelector( final Iterable<MutatorFactory> mutatorFactoryInstances )
-    {
-        mapMutators( mutatorFactoryInstances );
-    }
-
-    @PostConstruct
-    public void mapPresets()
     {
         mapMutators( mutatorFactoryInstances );
     }
@@ -96,7 +83,7 @@ public class MutatorSelector
             }
 
             final GraphMutator mutatorInstance = factory.newMutator( mutator );
-            
+
             logger.info( "Returning mutator: {} for ID: {}", mutatorInstance, mutator );
             return mutatorInstance;
         }


### PR DESCRIPTION
The MutatorSelector was constructed by the 0-argument ctor which calls
the mapMutators(). The same method is then called as part of the
@PostConstruct method. So it is called twice but with different
parameters.

The first method uses result of
```  ServiceLoader.load( MutatorFactory.class )```
which is ok, but the second call uses injected
```  Instance<MutatorFactory> mutatorFactoryInstances```
which for some reason does not contain the NoOpGraphMutatorFactory.

So removing the @PostConstruct method along with injected
Instance<MutatorFactory> seems to work ok.

The stacktrace was:
```
Mar 16, 2017 2:06:05 PM io.undertow.servlet.api.LoggingExceptionHandler handleThrowable
ERROR: UT005023: Exception handling request to /api/depgraph/repo/urlmap
org.jboss.resteasy.spi.UnhandledException: java.lang.IllegalArgumentException: Invalid mutator: NOOP
    at org.jboss.resteasy.core.ExceptionHandler.handleApplicationException(ExceptionHandler.java:76)
    at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:212)
    at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:166)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:393)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:200)
    at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
    at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
    at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:61)
    at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
    at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
    at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:56)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:45)
    at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:63)
    at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:58)
    at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:70)
    at io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:76)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:261)
    at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:247)
    at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:76)
    at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:166)
    at io.undertow.server.Connectors.executeRootHandler(Connectors.java:197)
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:764)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: Invalid mutator: NOOP
    at org.commonjava.cartographer.graph.mutator.MutatorSelector.getGraphMutator(MutatorSelector.java:95)
    at org.commonjava.cartographer.graph.mutator.MutatorSelector$Proxy$_$$_WeldClientProxy.getGraphMutator(Unknown Source)
    at org.commonjava.cartographer.graph.RecipeResolver.resolveMutator(RecipeResolver.java:357)
    at org.commonjava.cartographer.graph.RecipeResolver.resolveMutators(RecipeResolver.java:372)
    at org.commonjava.cartographer.graph.RecipeResolver.resolveMutators(RecipeResolver.java:384)
    at org.commonjava.cartographer.graph.RecipeResolver.resolve(RecipeResolver.java:97)
    at org.commonjava.cartographer.graph.RecipeResolver$Proxy$_$$_WeldClientProxy.resolve(Unknown Source)
    at org.commonjava.cartographer.INTERNAL.ops.ResolveOpsImpl.resolveRepositoryContents(ResolveOpsImpl.java:108)
    at org.commonjava.cartographer.INTERNAL.ops.ResolveOpsImpl$Proxy$_$$_WeldClientProxy.resolveRepositoryContents(Unknown Source)
    at org.commonjava.cartographer.rest.ctl.RepositoryController.resolveContents(RepositoryController.java:264)
    at org.commonjava.cartographer.rest.ctl.RepositoryController.getUrlMap(RepositoryController.java:104)
    at org.commonjava.cartographer.rest.ctl.RepositoryController$Proxy$_$$_WeldClientProxy.getUrlMap(Unknown Source)
    at org.commonjava.cartographer.rest.resources.RepositoryResource.getUrlMap(RepositoryResource.java:95)
    at org.commonjava.cartographer.rest.resources.RepositoryResource$Proxy$_$$_WeldClientProxy.getUrlMap(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:137)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:296)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:250)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:237)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:377)
    ... 27 more
```