### PR TITLE
Fix logging in standalone Cartographer

### DIFF
--- a/cartographer/pom.xml
+++ b/cartographer/pom.xml
@@ -150,10 +150,6 @@
       <artifactId>configuration-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/deployments/standalone-rest/pom.xml
+++ b/deployments/standalone-rest/pom.xml
@@ -41,6 +41,16 @@
     <dependency>
       <groupId>org.commonjava.cartographer</groupId>
       <artifactId>cartographer</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-jdk14</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.commonjava.cartographer</groupId>

--- a/deployments/standalone-rest/src/main/assembly/launcher.xml
+++ b/deployments/standalone-rest/src/main/assembly/launcher.xml
@@ -55,7 +55,6 @@
       <excludes>
         <exclude>org.commonjava.cartographer*</exclude>
         <exclude>org.commonjava*</exclude>
-        <exclude>ch.qos.logback:logback-classic</exclude>
       </excludes>
       <outputDirectory>lib/thirdparty</outputDirectory>
     </dependencySet>

--- a/deployments/standalone-rest/src/main/conf/logging/logback.xml
+++ b/deployments/standalone-rest/src/main/conf/logging/logback.xml
@@ -24,13 +24,13 @@
       <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  
+
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <file>${carto.home}/var/log/cartographer/cartographer.log</file>
       <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
         <fileNamePattern>${carto.home}/var/log/cartographer/cartographer.%i.log</fileNamePattern>
 
-        <maxHistory>20</maxHistory>
+        <maxIndex>20</maxIndex>
       </rollingPolicy>
 
       <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
@@ -53,5 +53,5 @@
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>
-  
+
 </configuration>


### PR DESCRIPTION
The problem was that the logback.xml in etc/cartographer/logging/ was
ignored and all logging happened only in stderr and nothing in the
specified file.

* use only logback-classic in the cartographer-standalone-rest - exclude
  other implementations from dependencies pulled in by module
  cartographer
* remove duplicate logback-classic dependency from cartographer module
  - it is inherited from cartographer-parent
* do not exclude logback-classic jar from the assembly
* fix setting of rolling policy - it reported an error when starting:
  |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@33:21 - no applicable action for [maxHistory], current pattern is [[configuration][appender][rollingPolicy][maxHistory]]