### PR TITLE
Add missing equals/hashcode methods in filters

### DIFF
--- a/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/DependencyFilter.java
+++ b/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/DependencyFilter.java
@@ -90,24 +90,26 @@ public class DependencyFilter
 
         if ( scope != null )
         {
-            if ( useImpliedScopes && !scope.implies( dr.getScope() ) )
+            DependencyScope drScope = dr.getScope();
+            if ( useImpliedScopes && !scope.implies( drScope ) )
             {
 //                logger.debug( "NO (wrong implied scope)" );
                 return false;
             }
-            else if ( !useImpliedScopes && scope != dr.getScope() )
+            else if ( !useImpliedScopes && scope != drScope )
             {
 //                logger.debug( "NO (wrong direct scope)" );
                 return false;
             }
         }
 
-        if ( !includeManagedRelationships() && dr.isManaged() )
+        boolean drManaged = dr.isManaged();
+        if ( !includeManagedRelationships() && drManaged )
         {
 //            logger.debug( "NO (excluding managed)" );
             return false;
         }
-        else if ( !includeConcreteRelationships() && !dr.isManaged() )
+        else if ( !includeConcreteRelationships() && !drManaged )
         {
 //            logger.debug( "NO (excluding concrete)" );
             return false;

--- a/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/DependencyOnlyFilter.java
+++ b/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/DependencyOnlyFilter.java
@@ -71,8 +71,9 @@ public class DependencyOnlyFilter
         {
             if ( scope == s || ( useImpliedScope && s.implies( scope ) ) )
             {
-                if ( ( dr.isManaged() && includeManagedRelationships() )
-                    || ( !dr.isManaged() && includeConcreteRelationships() ) )
+                boolean drManaged = dr.isManaged();
+                if ( ( drManaged && includeManagedRelationships() )
+                    || ( !drManaged && includeConcreteRelationships() ) )
                 {
                     return true;
                 }

--- a/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/ExcludingFilter.java
+++ b/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/ExcludingFilter.java
@@ -114,4 +114,56 @@ public class ExcludingFilter
         return filter.getAllowedTypes();
     }
 
+    @Override
+    public boolean equals( final Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+        if ( obj == null )
+        {
+            return false;
+        }
+        if ( getClass() != obj.getClass() )
+        {
+            return false;
+        }
+        final ExcludingFilter other = (ExcludingFilter) obj;
+        if ( excludedSubgraphs == null )
+        {
+            if ( other.excludedSubgraphs != null )
+            {
+                return false;
+            }
+        }
+        else if ( !excludedSubgraphs.equals( other.excludedSubgraphs ) )
+        {
+            return false;
+        }
+        if ( filter == null )
+        {
+            if ( other.filter != null )
+            {
+                return false;
+            }
+        }
+        else if ( !filter.equals( other.filter ) )
+        {
+            return false;
+        }
+        return true;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( excludedSubgraphs == null ) ? 0 : excludedSubgraphs.hashCode() );
+        result = prime * result + ( ( filter == null ) ? 0 : filter.hashCode() );
+        return result;
+    }
+
 }

--- a/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/PluginRuntimeFilter.java
+++ b/relationships/api/src/main/java/org/commonjava/cartographer/graph/filter/PluginRuntimeFilter.java
@@ -84,6 +84,18 @@ public class PluginRuntimeFilter
     }
 
     @Override
+    public boolean equals( final Object obj )
+    {
+        return obj instanceof PluginRuntimeFilter;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return PluginRuntimeFilter.class.hashCode() + 1;
+    }
+
+    @Override
     public String getCondensedId()
     {
         return getLongId();

--- a/relationships/drivers/neo4j-embedded/src/main/java/org/commonjava/cartographer/graph/spi/neo4j/model/NeoDependencyRelationship.java
+++ b/relationships/drivers/neo4j-embedded/src/main/java/org/commonjava/cartographer/graph/spi/neo4j/model/NeoDependencyRelationship.java
@@ -40,6 +40,8 @@ public final class NeoDependencyRelationship
 
     private static final long serialVersionUID = 1L;
 
+    private DependencyScope scope;
+
     public NeoDependencyRelationship( final Relationship rel )
     {
         super(rel, RelationshipType.DEPENDENCY);
@@ -48,12 +50,16 @@ public final class NeoDependencyRelationship
     @Override
     public final DependencyScope getScope()
     {
-        final String scopeStr = Conversions.getStringProperty( Conversions.SCOPE, rel );
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.debug("Got scope from relationship: {} of: {}", rel, scopeStr );
+        if (scope == null)
+        {
+            final String scopeStr = Conversions.getStringProperty( Conversions.SCOPE, rel );
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.debug("Got scope from relationship: {} of: {}", rel, scopeStr );
 
-        DependencyScope scope = DependencyScope.getScope( scopeStr );
-        return scope == null ? DependencyScope.compile : scope;
+            scope = DependencyScope.getScope( scopeStr );
+            scope = scope == null ? DependencyScope.compile : scope;
+        }
+        return scope;
     }
 
     @Override


### PR DESCRIPTION
Those missing methods were indirectly causing OutOfMemoryError in paths
method. The filters were never considered to be in the filters of actual
OrFilter, so the same filter was added many times and in the end it
failed even when I started Cartographer with Xmx 32 GB.

Also added caching of scope in NeoDependencyRelationship to not spit the
resolved scope message in the log with every call (called from multiple
places for a single relationship).